### PR TITLE
Minor fixup of filename in docs

### DIFF
--- a/docs/notebooks/Working_with_ipyparallel.ipynb
+++ b/docs/notebooks/Working_with_ipyparallel.ipynb
@@ -94,7 +94,7 @@
    "outputs": [],
    "source": [
     "m = load_biomodel(68)\n",
-    "save_model('bm69.cps', model=m)\n",
+    "save_model('bm68.cps', model=m)\n",
     "remove_datamodel(m)"
    ]
   },


### PR DESCRIPTION
Hey Frank ich hab gerade durch die Docs gebrowsed und mir ist das hier aufgefallen.
Ich nehme an das ist ein typo.
Habe das hier mal mit dem Web-Interface von github probiert zu patchen.
Ich hoffe das macht Sinn. Habe den Fix nicht ausprobieren können also vergib mir bitten wenn da irgendwas nicht passt 😅